### PR TITLE
add sarcastic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ positional arguments:
 optional arguments:
   -h, --help          show this help message and exit
   --convert , --con   Convert the case of the string. Allowed options are:
-                      upper, lower, title, sentence, all
+                      upper, lower, title, sentence, sarcastic, all
 ```
 
 #### Author

--- a/convertcase.py
+++ b/convertcase.py
@@ -1,8 +1,17 @@
 import argparse as a
+from itertools import cycle
+
+
+def alternating_case(s):
+    """
+    Given a string, s, returns the string with aLtErNaTiNg cAsE
+    """
+    case_function = cycle([str.lower, str.upper])
+    return ''.join(func(character) for character, func in zip(s, case_function))
 
 
 def arg_parse():
-    conversions = ['upper', 'lower', 'title', 'sentence', 'all']
+    conversions = ['upper', 'lower', 'title', 'sentence', 'sarcastic', 'all']
 
     p = a.ArgumentParser(description='Change the case of a word or sentence.\nWrap sentences with single quotes.')
     p.add_argument('string', type=str,
@@ -20,12 +29,14 @@ def main():
     lowercase = args.string.lower()
     title = args.string.title()
     sentence = args.string.capitalize()
-
+    sarcastic = alternating_case(args.string)
     # Add conversions to conversion list
     conversion = [uppercase,
                   lowercase,
                   title,
-                  sentence]
+                  sentence,
+                  sarcastic,
+                 ]
 
     # Uppercase
     if args.convert == 'upper':
@@ -39,6 +50,9 @@ def main():
     # Sentence
     elif args.convert == 'sentence':
         print(conversion[3])
+    # Sarcastic
+    elif args.convert == 'sarcastic':
+        print(conversion[4])
     # All conversions
     elif args.convert == 'all':
         print(*conversion, sep='\n')


### PR DESCRIPTION
For my friend, Omar.

I've added a functionality I think will be useful for this program: a `sarcastic` option.

For example

```bash
convertcase.py --con sarcastic "You should seriously consider merging this change"
```

Would yield the output:

```
yOu sHoUlD SeRiOuSlY CoNsIdEr mErGiNg tHiS ChAnGe
```

This covers a common use case where you may want to convey a mocking or sarcastic tone to the reader.